### PR TITLE
タスクが存在しない場合、indexページに飛ぶとエラーを吐くバグを解決

### DIFF
--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -9,10 +9,9 @@ module TasksHelper
           label << l.name
         end
         @check = label.uniq
-      else
-        @check = [""]
       end
     end
+    @check = [""] if @check.nil?
     return @check
   end
 end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -46,6 +46,7 @@
   </div>
 
   <% end %>
+  
 </div>
 <br>
 <br>


### PR DESCRIPTION
label_catcherの記述を変更しました。
最後の返り値を返す際にnilの場合にからの配列を挿入するように追記。