### PR TITLE
herokuにおいてDELETEメソッドが起動しなくなるバグのため、assetsファイルないの記述を追記

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
+//= require jquery_ujs
 //= require bootstrap/dist/js/bootstrap.bundle.min.js
 //= require jquery/dist/jquery.js
 //= require bootstrap/dist/js/bootstrap.min


### PR DESCRIPTION
暫定的に実施。